### PR TITLE
Only apply price when a rule is applied

### DIFF
--- a/Model/PriceListData.php
+++ b/Model/PriceListData.php
@@ -113,9 +113,10 @@ class PriceListData extends \Magento\Framework\Model\AbstractModel
     /**
      * @param $productId
      * @param $originalPrice
+     * @param bool $appliedPriceList
      * @return float
      */
-    public function getProductPrice($productId, $originalPrice): ?float
+    public function getProductPrice($productId, $originalPrice, &$appliedPriceList): ?float
     {
         $listIds = $this->getLists();
 
@@ -137,6 +138,7 @@ class PriceListData extends \Magento\Framework\Model\AbstractModel
             // this to form of using the cheapest for final price.
             if ($newPrice > $listPrice) {
                 $listPrice = $newPrice;
+                $appliedPriceList = true;
             }
         }
 

--- a/Plugin/Magento/Catalog/Api/ProductRepositoryInterface.php
+++ b/Plugin/Magento/Catalog/Api/ProductRepositoryInterface.php
@@ -44,19 +44,24 @@ class ProductRepositoryInterface
         \Magento\Catalog\Api\ProductRepositoryInterface $subject,
         $result
     ) {
-        if ($this->priceListData->getGeneralConfig('enable')) {
-            $price = $this->priceListData->getProductPrice($result->getId(), $result->getPrice());
-
-            $extension = $this->getExtensionAttributes($result);
-            $extension->setCustomPrice($price);
-            $extension->setOriginalPrice($result->getPrice());
-
-            $result->setExtensionAttributes($extension);
+        if (!$this->priceListData->getGeneralConfig('enable')) {
+            return $result;
         }
+
+        $price = $this->priceListData->getProductPrice($result->getId(), $result->getPrice(), $appliedPriceList);
+
+        if (!$appliedPriceList) {
+            return $result;
+        }
+
+        $extension = $this->getExtensionAttributes($result);
+        $extension->setCustomPrice($price);
+        $extension->setOriginalPrice($result->getPrice());
+
+        $result->setExtensionAttributes($extension);
 
         return $result;
     }
-
 
     /**
      * Get a ProductExtensionInterface object, creating it if it is not yet created
@@ -64,8 +69,10 @@ class ProductRepositoryInterface
      * @param ProductInterface $customer
      * @return ProductExtensionInterface|null
      */
-    private function getExtensionAttributes(ProductInterface $customer)
-    {
+    private
+    function getExtensionAttributes(
+        ProductInterface $customer
+    ) {
         $extensionAttributes = $customer->getExtensionAttributes();
         if (!$extensionAttributes) {
             $extensionAttributes = $this->extensionFactory->create();

--- a/Plugin/Magento/Catalog/Model/Product.php
+++ b/Plugin/Magento/Catalog/Model/Product.php
@@ -38,14 +38,14 @@ class Product
             return $result;
         }
 
-        $newPrice = $this->priceListData->getProductPrice($subject->getId(), $price);
+        $newPrice = $this->priceListData->getProductPrice($subject->getId(), $price, $appliedPriceList);
 
         /** get the lowest price */
         if ($newPrice < $price || $price == 0) {
             $price = $newPrice;
         }
 
-        if ($this->priceListData->getGeneralConfig('disable_tier_pricing')) {
+        if ($appliedPriceList && $this->priceListData->getGeneralConfig('disable_tier_pricing')) {
             $subject->setTierPrices([]);
         }
 


### PR DESCRIPTION
The setting **Disable tier pricing** does not check if a price list is actually applied, which is does say in the description: _Disables tier pricing for a product when there is a price rule active_.
This PR adds this feature to only apply a pricelist when there is one.



